### PR TITLE
VICTOR compatability

### DIFF
--- a/src/PetThermoTools/MELTS.py
+++ b/src/PetThermoTools/MELTS.py
@@ -3,6 +3,14 @@ import pandas as pd
 import sys
 import time
 
+import os
+try:
+    # If we are on VICTOR...
+    if os.path.exists('/home/jovyan/shared/Models/alphaMELTS'):
+        sys.path.append('/home/jovyan/shared/Models/alphaMELTS')
+except:
+    raise Exception("Could not set path to alphaMELTS")
+
 def equilibrate_MELTS(Model = None, P_bar = None, T_C = None, comp = None, fO2_buffer = None, fO2_offset = None, Suppress = None):
     Results = {}
     Affinity = {}

--- a/src/PetThermoTools/Path.py
+++ b/src/PetThermoTools/Path.py
@@ -10,6 +10,18 @@ import time
 import sys
 from tqdm.notebook import tqdm, trange
 
+# https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook/39662359#39662359
+try:
+    shell = get_ipython().__class__.__name__
+    if shell == 'ZMQInteractiveShell':
+        from wurlitzer import sys_pipes as pipes # Jupyter notebook or qtconsole
+    elif shell == 'TerminalInteractiveShell':
+        pipes = None  # Terminal running IPython
+    else:
+        pipes = None  # Other type (?)
+except:
+    pipes = None     # Probably standard Python interpreter (or wurlitzer not available)
+
 def multi_path(cores = None, Model = None, bulk = None, comp = None, Frac_solid = None, Frac_fluid = None, 
                T_C = None, T_path_C = None, T_start_C = None, T_end_C = None, dt_C = None, 
                P_bar = None, P_path_bar = None, P_start_bar = None, P_end_bar = None, dp_bar = None, 
@@ -573,7 +585,11 @@ def path(q, index, *, Model = None, comp = None, Frac_solid = None, Frac_fluid =
     Results = {}
     if "MELTS" in Model:
         try:
-            Results = path_MELTS(Model = Model, comp = comp, Frac_solid = Frac_solid, Frac_fluid = Frac_fluid, T_C = T_C, T_path_C = T_path_C, T_start_C = T_start_C, T_end_C = T_end_C, dt_C = dt_C, P_bar = P_bar, P_path_bar = P_path_bar, P_start_bar = P_start_bar, P_end_bar = P_end_bar, dp_bar = dp_bar, isenthalpic = isenthalpic, isentropic = isentropic, isochoric = isochoric, find_liquidus = find_liquidus, fO2_buffer = fO2_buffer, fO2_offset = fO2_offset, fluid_sat = fluid_sat, Crystallinity_limit = Crystallinity_limit)
+            if pipes is not None:
+                with pipes():
+                    Results = path_MELTS(Model = Model, comp = comp, Frac_solid = Frac_solid, Frac_fluid = Frac_fluid, T_C = T_C, T_path_C = T_path_C, T_start_C = T_start_C, T_end_C = T_end_C, dt_C = dt_C, P_bar = P_bar, P_path_bar = P_path_bar, P_start_bar = P_start_bar, P_end_bar = P_end_bar, dp_bar = dp_bar, isenthalpic = isenthalpic, isentropic = isentropic, isochoric = isochoric, find_liquidus = find_liquidus, fO2_buffer = fO2_buffer, fO2_offset = fO2_offset, fluid_sat = fluid_sat, Crystallinity_limit = Crystallinity_limit)
+            else:
+                Results = path_MELTS(Model = Model, comp = comp, Frac_solid = Frac_solid, Frac_fluid = Frac_fluid, T_C = T_C, T_path_C = T_path_C, T_start_C = T_start_C, T_end_C = T_end_C, dt_C = dt_C, P_bar = P_bar, P_path_bar = P_path_bar, P_start_bar = P_start_bar, P_end_bar = P_end_bar, dp_bar = dp_bar, isenthalpic = isenthalpic, isentropic = isentropic, isochoric = isochoric, find_liquidus = find_liquidus, fO2_buffer = fO2_buffer, fO2_offset = fO2_offset, fluid_sat = fluid_sat, Crystallinity_limit = Crystallinity_limit)
             q.put([Results, index])
         except:
             q.put([])


### PR DESCRIPTION
Two edits to make running PetThermoTools in notebooks simpler on VICTOR:
- One tests whether ‘/home/jovyan/shared/Models/alphaMELTS' exists (i.e. are we on VICTOR?) and adds it the system path when PetThermoTools is imported. So no need for admin access.
- The other applies the wurlitzer package within the PetThermoTools code if it is available (i.e. not Windows) so that MELTS stdout and stderr are not printed but you still get the calculation results back.